### PR TITLE
Fix GitHub action nanoid missing

### DIFF
--- a/tockspecial/package.json
+++ b/tockspecial/package.json
@@ -36,7 +36,8 @@
     "puppeteer-extra": "^3.3.6",
     "puppeteer-extra-plugin-stealth": "^2.11.2",
     "user-agents": "^1.1.540",
-    "usps-webtools": "^1.0.7"
+    "usps-webtools": "^1.0.7",
+    "nanoid": "^3.3.6"
   },
   "devDependencies": {
     "c8": "^10.1.3",


### PR DESCRIPTION
## Summary
- add `nanoid` dependency in `tockspecial` package

## Testing
- `npm test` *(fails: `jest` not found)*